### PR TITLE
Ajustes de dashboard de curator

### DIFF
--- a/app/apply/page.tsx
+++ b/app/apply/page.tsx
@@ -3,6 +3,9 @@ import CTAButton from '@/components/ui/CTAButton';
 import ApplicationForm from './ApplicationForm';
 import { getLocale } from '@/lib/i18n/getLocale';
 import { t } from '@/lib/i18n/t';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -17,6 +20,12 @@ export async function generateMetadata() {
 
 export default async function ApplyPage() {
   const locale = await getLocale();
+  const session = await getServerSession(authOptions);
+
+  // Redirect if already a curator
+  if (session?.user?.role === 'CURATOR') {
+    redirect('/dashboard/curator');
+  }
   
   return (
     <main className="min-h-[80vh]">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,7 +45,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang={locale} className="h-full">
       <body className="min-h-screen bg-white text-neutral-900 antialiased">
-        <ClientProviders>
+        <ClientProviders locale={locale}>
           <Header />
           {children}
         </ClientProviders>

--- a/components/ClientProviders.tsx
+++ b/components/ClientProviders.tsx
@@ -4,15 +4,18 @@ import { SessionProvider } from "next-auth/react";
 import { CartProvider } from "@/contexts/CartContext";
 import { FavoritesProvider } from "@/contexts/FavoritesContext";
 import { I18nProvider } from "@/components/i18n/I18nProvider";
-import { getLocaleFromCookie } from "@/lib/i18n/getLocale";
+import type { Locale } from "@/lib/i18n/getLocale";
 
-export default function ClientProviders({ children }: { children: React.ReactNode }) {
-  // Read locale from cookie on initial render (client-side only)
-  const initialLocale = typeof window !== 'undefined' ? getLocaleFromCookie() : 'es'
-
+export default function ClientProviders({ 
+  children,
+  locale
+}: { 
+  children: React.ReactNode,
+  locale: Locale
+}) {
   return (
     <SessionProvider>
-      <I18nProvider initialLocale={initialLocale}>
+      <I18nProvider initialLocale={locale}>
         <CartProvider>
           <FavoritesProvider>
             {children}

--- a/components/CuratorDashboard.tsx
+++ b/components/CuratorDashboard.tsx
@@ -97,6 +97,27 @@ export default function CuratorDashboard({ curator }: CuratorDashboardProps) {
       icon: <Package className="w-6 h-6" />,
       href: '/dashboard/curator/orders',
       color: 'bg-gray-100 text-carbon hover:bg-gray-200'
+    },
+    {
+      title: 'Ask Nigel',
+      description: 'Get AI help with your store strategy',
+      icon: <MessageCircle className="w-6 h-6" />,
+      href: '/dashboard/curator/ask-nigel',
+      color: 'bg-indigo-50 text-indigo-600 hover:bg-indigo-100'
+    },
+    {
+      title: 'Collaborations',
+      description: 'Find Brands and Curators to work with',
+      icon: <Users className="w-6 h-6" />,
+      href: '/dashboard/curator/collaborations',
+      color: 'bg-purple-50 text-purple-600 hover:bg-purple-100'
+    },
+    {
+      title: 'Engagement',
+      description: 'Analyze your audience interaction',
+      icon: <TrendingUp className="w-6 h-6" />,
+      href: '/dashboard/curator/engagement',
+      color: 'bg-orange-50 text-orange-600 hover:bg-orange-100'
     }
   ]
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,7 +18,10 @@ export default function Header() {
 
   const NAV = [
     { href: '/explore', label: t('nav.dress') },
-    { href: '/apply', label: t('nav.sell') },
+    { 
+      href: user?.role === 'CURATOR' ? '/dashboard/curator' : '/apply', 
+      label: user?.role === 'CURATOR' ? t('user.curatorDashboard') : t('nav.sell') 
+    },
   ];
 
   return (

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -91,6 +91,7 @@
   "sell.title": "Sell Like Them",
   "sell.subtitle": "Turn your wardrobe into a store. Join curators selling their favorite pieces.",
   "sell.cta": "Apply now",
+  "common.add": "Add Product",
   "common.loading": "Loading...",
   "common.error": "Error",
   "common.success": "Success",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -91,6 +91,7 @@
   "sell.title": "Vende con LikeThem",
   "sell.subtitle": "Convierte tu guardarropa en una tienda. Únete a curadores que venden sus piezas favoritas.",
   "sell.cta": "Aplicar ahora",
+  "common.add": "Subir Producto",
   "common.loading": "Cargando...",
   "common.error": "Error",
   "common.success": "Éxito",


### PR DESCRIPTION
This pull request introduces several improvements focused on user authentication, localization, and user experience for curators. The most significant changes include redirecting authenticated curators to their dashboard, passing locale information more reliably to client providers, updating navigation logic based on user roles, expanding the curator dashboard with new features, and adding new translation keys.

**Authentication and Access Control:**
- Curators who are already authenticated are now automatically redirected from the apply page to their dashboard, preventing them from accessing the application form again [[1]](diffhunk://#diff-d33a562ee90a42b194dcc5f91729f9a1a7bd9ddcff621875187f83e977f91fe2R6-R8) [[2]](diffhunk://#diff-d33a562ee90a42b194dcc5f91729f9a1a7bd9ddcff621875187f83e977f91fe2R23-R28).

**Localization and Providers:**
- The `ClientProviders` component now receives the locale from the server and passes it down, ensuring consistent localization across client-side components [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL48-R48) [[2]](diffhunk://#diff-2aa2028ed5482cda4978a448956580caa846cb1646ba89d82d25e920dfdb70d5L7-R18).

**Navigation and User Experience:**
- The navigation bar in the `Header` component dynamically updates the "Sell" link to direct curators to their dashboard and adjusts the label accordingly, improving the experience for logged-in curators.

**Curator Dashboard Enhancements:**
- The curator dashboard now includes new sections: "Ask Nigel" (AI help), "Collaborations," and "Engagement," providing curators with additional tools and analytics.

**Translations:**
- Added new translation keys for "Add Product" in both English and Spanish locale files [[1]](diffhunk://#diff-5a97d26a281f5595099468dfdbe761ff60a5a7f4d352b5748375a46ba1d6c713R94) [[2]](diffhunk://#diff-c179999ab837008d147736edc01e2563b1355b541ce7c7fa0f2be9522b9f34c9R94).